### PR TITLE
fix: add missing solid-js/store alias in webpack config

### DIFF
--- a/nativescript.webpack.js
+++ b/nativescript.webpack.js
@@ -24,6 +24,10 @@ const solid = (config, env) => {
       path.resolve(solidPath, `universal/dist/${env.production ? 'universal' : 'dev'}.js`)
     )
     .set(
+      'solid-js/store',
+      path.resolve(solidPath, `store/dist/${env.production ? 'store' : 'dev'}.js`)
+    )
+    .set(
       'solid-js',
       path.resolve(solidPath, `dist/${env.production ? 'solid' : 'dev'}.js`)
     );


### PR DESCRIPTION
`solid-js/store` export was missing in webpack config aliases. It's required if you want to use `useStore` hook.