### PR TITLE
Resolve alias for solid-js/web to web.

### DIFF
--- a/nativescript.webpack.js
+++ b/nativescript.webpack.js
@@ -30,6 +30,10 @@ const solid = (config, env) => {
     .set(
       'solid-js',
       path.resolve(solidPath, `dist/${env.production ? 'solid' : 'dev'}.js`)
+    )
+    .set(
+      'solid-js/web',
+      path.resolve(solidPath, `dist/${env.production ? 'web' : 'dev'}.js`)
     );
 
   config.module


### PR DESCRIPTION
Some libraries such as `@tanstack/solid-query` import  some APIs from`solid-js/web`.  By default solid-js picks `/server.js` file for NativeScript which results in incorrect behavior. Hence we add an alias for `solid-js/web` import to point to **dist/web.js**.