### PR TITLE
Allow babel version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/nativescript-community/solid-js/issues",
   "homepage": "https://github.com/nativescript-community/solid-js",
   "peerDependencies": {
-    "@babel/preset-typescript": "7.23.3",
+    "@babel/preset-typescript": "^7.23.3",
     "babel-preset-solid": "^1.8.9",
     "dominative": "^0.1.2",
     "solid-js": "^1.8.11"


### PR DESCRIPTION
Fixing babel's version breaks newer projects using the latest npm version. E.g., when using solid's default template for nativescript, `npm i` will fail since it can't resolve both the version fixed here and the top level babel version from the template.

```
$ npm i
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: explore-ns-wallet@1.0.0
npm error Found: @babel/preset-typescript@7.25.7
npm error node_modules/@babel/preset-typescript
npm error   dev @babel/preset-typescript@"^7.25.7" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @babel/preset-typescript@"7.23.3" from @nativescript-community/solid-js@0.0.7
npm error node_modules/@nativescript-community/solid-js
npm error   @nativescript-community/solid-js@"^0.0.7" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```